### PR TITLE
Update altinity-kb-converting-mergetree-to-replicated.md

### DIFF
--- a/content/en/altinity-kb-setup-and-maintenance/altinity-kb-converting-mergetree-to-replicated.md
+++ b/content/en/altinity-kb-setup-and-maintenance/altinity-kb-converting-mergetree-to-replicated.md
@@ -33,13 +33,17 @@ create table foo_replicated as foo
 Engine ReplicatedMergeTree('/clickhouse/{cluster}/tables/{database}/{table}/{shard}','{replica}')
 partition by toYYYYMM(D) order by A;
 
-SELECT DISTINCT 'ALTER TABLE foo_replicated ATTACH PARTITION ID \'' || partition_id || '\' FROM foo;' from system.parts WHERE table = 'foo';
+SYSTEM STOP MERGES;
+
+SELECT DISTINCT 'ALTER TABLE foo_replicated ATTACH PARTITION ID \'' || partition_id || '\' FROM foo;' from system.parts WHERE table = 'foo' AND is_active;
 ┌─concat('ALTER TABLE foo_replicated ATTACH PARTITION ID \'', partition_id, '\' FROM foo;')─┐
 │ ALTER TABLE foo_replicated ATTACH PARTITION ID '202111' FROM foo;                         │
 │ ALTER TABLE foo_replicated ATTACH PARTITION ID '202201' FROM foo;                         │
 └───────────────────────────────────────────────────────────────────────────────────────────┘
 
 clickhouse-client -q "SELECT DISTINCT 'ALTER TABLE foo_replicated ATTACH PARTITION ID \'' || partition_id || '\' FROM foo;' from system.parts WHERE table = 'foo' format TabSeparatedRaw" |clickhouse-client -mn
+
+SYSTEM START MERGES;
 
 SELECT count() FROM foo_replicated;
 ┌───count()─┐


### PR DESCRIPTION
[x] I have read the CLA Document and I hereby sign the CLA

System.partitions table can contain inactive partitions. When implementing a migration inspired by this document for PostHog, I got bit by the missing `is_active` filter.

Also added a suggestion to drop merges since these can change what partitions are available between commands.