### PR TITLE
kafka_max_block_size default value formula fix in altinity-kb-kafka-main-parsing-loop.md

### DIFF
--- a/content/en/altinity-kb-integrations/altinity-kb-kafka/altinity-kb-kafka-main-parsing-loop.md
+++ b/content/en/altinity-kb-integrations/altinity-kb-kafka/altinity-kb-kafka-main-parsing-loop.md
@@ -26,7 +26,7 @@ These usually should not be adjusted:
 You may want to adjust those depending on your scenario:
 
 * `kafka_flush_interval_ms` = stream_poll_timeout_ms (7500ms)
-* `kafka_max_block_size` = min_insert_block_size / kafka_num_consumers (for the single consumer: 1048576)
+* `kafka_max_block_size` = max_insert_block_size / kafka_num_consumers (for the single consumer: 1048576)
 
 ## See also
 


### PR DESCRIPTION
There is a typo in `kafka_max_block_size` default value formula in the last string of _Important Settings_ paragraph:
```
kafka_max_block_size = min_insert_block_size / kafka_num_consumers (for the single consumer: 1048576)
```
according to
https://github.com/ClickHouse/ClickHouse/blob/1e9d80a9c23b8c7e4c27f1d9e98b9c9fe4166254/src/Storages/Kafka/StorageKafka.cpp#L485
`min_insert_block_size` should be replaced with `max_insert_block_size`